### PR TITLE
Stop keeping track of command numbers by hand.

### DIFF
--- a/commands.h
+++ b/commands.h
@@ -37,5 +37,5 @@ Command commands[] = {
 	{ "pacman -Qo [file]", "list packages that own file", "owned" }
 };
 
-static const int NUM_COMMANDS = sizeof(commands) / sizeof(Command);
-static const int NUM_SYNONYMS = sizeof(synonyms) / sizeof(Synonym);
+#define NUM_COMMANDS (sizeof(commands) / sizeof(Command))
+#define NUM_SYNONYMS (sizeof(synonyms) / sizeof(Synonym))

--- a/commands.h
+++ b/commands.h
@@ -1,13 +1,10 @@
-#define NUM_COMMANDS 23
-#define NUM_SYNONYMS 3
-
-Synonym synonyms[NUM_SYNONYMS] = {
+Synonym synonyms[] = {
 	"display find list print show view",
 	"information status",
 	"remote upstream"
 };
 
-Command commands[NUM_COMMANDS] = {
+Command commands[] = {
 	/* command                     description        additional keywords */
 	{ "amixer -Mq set Master 1%-", "decrease volume", "down lower sound" },
 	{ "amixer -Mq set Master 1%+", "increase volume", "raise sound up" },
@@ -39,3 +36,6 @@ Command commands[NUM_COMMANDS] = {
 	{ "pacman -Ql [package]", "list files owned by package" },
 	{ "pacman -Qo [file]", "list packages that own file", "owned" }
 };
+
+static const int NUM_COMMANDS = sizeof(commands) / sizeof(Command);
+static const int NUM_SYNONYMS = sizeof(synonyms) / sizeof(Synonym);

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 #include "main.h"
 #include "commands.h"
 
-Result results[MAX_RESULTS];
+Result results[NUM_COMMANDS];
 
 int main(int argc, char **argv)
 {

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 #include "main.h"
 #include "commands.h"
 
-Result results[NUM_COMMANDS];
+Result results[MAX_RESULTS];
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Now we just need to modify the Commands and Synonyms array,
instead of keeping track of the NUM_COMMANDS and NUM_SYNONYMS by hand.
